### PR TITLE
add guid-parse benchmark

### DIFF
--- a/benchmarks/guid/comptime-guid-parse-bench.zig
+++ b/benchmarks/guid/comptime-guid-parse-bench.zig
@@ -9,6 +9,6 @@ pub fn setup(gpa: std.mem.Allocator, options: *bench.Options) ![]const u8 {
 
 pub fn run(gpa: std.mem.Allocator, zig_exe: []const u8) !void {
     return bench.exec(gpa, &[_][]const u8{
-        zig_exe, "build-exe", "comptime-guid-parse.zig",
+        zig_exe, "build-obj", "comptime-guid-parse.zig",
     }, .{});
 }

--- a/benchmarks/guid/comptime-guid-parse-bench.zig
+++ b/benchmarks/guid/comptime-guid-parse-bench.zig
@@ -1,0 +1,14 @@
+const std = @import("std");
+const bench = @import("root");
+
+pub fn setup(gpa: std.mem.Allocator, options: *bench.Options) ![]const u8 {
+    _ = gpa;
+    options.useChildProcess();
+    return options.zig_exe;
+}
+
+pub fn run(gpa: std.mem.Allocator, zig_exe: []const u8) !void {
+    return bench.exec(gpa, &[_][]const u8{
+        zig_exe, "build-exe", "comptime-guid-parse.zig",
+    }, .{});
+}

--- a/benchmarks/guid/comptime-guid-parse.zig
+++ b/benchmarks/guid/comptime-guid-parse.zig
@@ -1,0 +1,14 @@
+const std = @import("std");
+
+pub fn main() void {}
+
+comptime {
+    const count = 5000;
+    var guid: [38]u8 = "{00000000-98b5-11cf-bb82-00aa00bdce0b}".*;
+
+    @setEvalBranchQuota(count * 2000);
+    var i: usize = 0;
+    while (i < count) : (i += 1) {
+        _ = std.os.windows.GUID.parse(&guid);
+    }
+}

--- a/benchmarks/manifest.json
+++ b/benchmarks/manifest.json
@@ -89,4 +89,10 @@
     "dir": "hello-world",
     "mainPath": "main-aarch64-linux.zig"
   }
+  "comptime-guid-parse": {
+    "description": "Parse a GUID at comptime",
+    "kind": "zig-bench",
+    "dir": "guid",
+    "mainPath": "comptime-guid-parse-bench.zig"
+  }
 }


### PR DESCRIPTION
Recently I got a pull request in zigwin32 to replace my custom-rolled GUID implementation with the one in `std`.  After testing the change, I realized that building zigwin32 went from less than a minute to a much longer affair.   I eventually killed it after what seemed like 15 minutes or so. It was hard for me to believe that the implementation could slow down compilation that much, but I created a small test app that confirmed it was actually the implementation.

I created this single file test program that can switch between both implementations (see the `use_std_guid` bool):

https://gist.github.com/marler8997/2ab2fc12190792308d233efcafe89ac3

This program consists of a copy of all the guids instantiated in zigwin32.  On my windows machine, using my guid implementation takes about 12 second to run `zig test guids.zig`, using the one from `std.os.windows.GUID` takes over 6 minutes!  I noticed on my Linux machine it went from 7 seconds to about 2 minutes, so the change isn't as drastic on linux.

This performance regression is so bad that I can't use `std.os.windows.GUID` in zigwin32 until this performance issue is fixed.  So I've added this benchmark for it and plan on pushing my implementation to `std` afterwards.

> NOTE TO SELF ABOUT WHY IT MIGHT BE SLOW: I removed the asserts and replaced the implementation in `std` with comptime-known offsets and it's still almost as slow.  I believe the main slow down is calling `parseUnsigned` at comptime.