### PR TITLE
Fix `build-self-hosted` benchmark

### DIFF
--- a/src/bench.zig
+++ b/src/bench.zig
@@ -26,9 +26,11 @@ pub fn main() !void {
     const allocator = arena.allocator();
 
     const zig_exe = std.mem.sliceTo(std.os.argv[1], 0);
+    const zig_src_root = zig_exe[0 .. std.mem.indexOf(u8, zig_exe, "zig/").? + 3];
 
-    var options = Options{ .zig_exe = zig_exe, .zig_src_root = zig_exe };
+    var options = Options{ .zig_exe = zig_exe, .zig_src_root = zig_src_root };
     const context = try app.setup(allocator, &options);
+
     const results = bench(options, app.run, .{ allocator, context });
     try std.json.stringify(results, std.json.StringifyOptions{}, std.io.getStdOut().writer());
 }

--- a/src/build-self-hosted/stage2.zig
+++ b/src/build-self-hosted/stage2.zig
@@ -21,9 +21,9 @@ pub fn setup(gpa: std.mem.Allocator, options: *bench.Options) !Context {
 
 pub fn run(gpa: std.mem.Allocator, context: Context) !void {
     return bench.exec(gpa, &.{
-        context.zig_exe,            "build",
-        "--build-file",             context.build_file_path,
-        "-p",                       OUTPUT_DIR,
-        "-Dskip-install-lib-files",
+        context.zig_exe, "build",
+        "--build-file",  context.build_file_path,
+        "-p",            OUTPUT_DIR,
+        "-Dno-lib",
     }, .{});
 }


### PR DESCRIPTION
Oops, here's a small fix for the `build-self-hosted` benchmark.

Changes:
- Update `zig build` flag from `-Dskip-install-lib-files` to `-Dno-lib`
- Fix `zig_src_root` option with the assumption that `zig_exe` has "zig/" source directory in its path, which should always be the case.